### PR TITLE
Implement rudimentary Playground support

### DIFF
--- a/WakaTime/WakaTime.m
+++ b/WakaTime/WakaTime.m
@@ -93,7 +93,7 @@ static WakaTime *sharedPlugin;
     CFAbsoluteTime currentTime = CFAbsoluteTimeGetCurrent();
     
     // check if we should send this action to api
-    if (currentFile && (![self.lastFile isEqualToString:currentFile] || self.lastTime + FREQUENCY * 60 < currentTime)) {
+    if (currentFile && (![self.lastFile isEqualToString:currentFile] || self.lastTime + FREQUENCY * 60 < currentTime)) {        
         self.lastFile = currentFile;
         self.lastTime = currentTime;
         [self sendAction:false];
@@ -144,11 +144,19 @@ static WakaTime *sharedPlugin;
         NSMutableArray *arguments = [NSMutableArray array];
         [arguments addObject:[NSHomeDirectory() stringByAppendingPathComponent:WAKATIME_CLI]];
         [arguments addObject:@"--file"];
-        [arguments addObject:self.lastFile];
+    
+        NSString* file = self.lastFile;
+        // Handle Playgrounds
+        if ([file.pathExtension isEqual: @"playground"]) {
+            file = [file stringByAppendingPathComponent:@"Contents.swift"];
+        }
+        
+        [arguments addObject:file];
         [arguments addObject:@"--plugin"];
         [arguments addObject:[NSString stringWithFormat:@"xcode/%@-%@ xcode-wakatime/%@", XCODE_VERSION, XCODE_BUILD, VERSION]];
         if (isWrite)
             [arguments addObject:@"--write"];
+        
         [task setArguments: arguments];
         [task launch];
     }

--- a/WakaTime/WakaTime.m
+++ b/WakaTime/WakaTime.m
@@ -147,8 +147,6 @@ static WakaTime *sharedPlugin;
         NSString* file = self.lastFile;
         // Handle Playgrounds
         if ([file.pathExtension isEqual: @"playground"]) {
-            [arguments addObject:@"--project"];
-            [arguments addObject:[[self.lastFile lastPathComponent] stringByDeletingPathExtension]];
             [arguments addObject:@"--language"];
             [arguments addObject:@"swift"];
             

--- a/WakaTime/WakaTime.m
+++ b/WakaTime/WakaTime.m
@@ -147,9 +147,6 @@ static WakaTime *sharedPlugin;
         NSString* file = self.lastFile;
         // Handle Playgrounds
         if ([file.pathExtension isEqual: @"playground"]) {
-            [arguments addObject:@"--language"];
-            [arguments addObject:@"swift"];
-            
             file = [file stringByAppendingPathComponent:@"Contents.swift"];
         }
 

--- a/WakaTime/WakaTime.m
+++ b/WakaTime/WakaTime.m
@@ -143,14 +143,19 @@ static WakaTime *sharedPlugin;
         
         NSMutableArray *arguments = [NSMutableArray array];
         [arguments addObject:[NSHomeDirectory() stringByAppendingPathComponent:WAKATIME_CLI]];
-        [arguments addObject:@"--file"];
     
         NSString* file = self.lastFile;
         // Handle Playgrounds
         if ([file.pathExtension isEqual: @"playground"]) {
+            [arguments addObject:@"--project"];
+            [arguments addObject:[[self.lastFile lastPathComponent] stringByDeletingPathExtension]];
+            [arguments addObject:@"--language"];
+            [arguments addObject:@"swift"];
+            
             file = [file stringByAppendingPathComponent:@"Contents.swift"];
         }
-        
+
+        [arguments addObject:@"--file"];
         [arguments addObject:file];
         [arguments addObject:@"--plugin"];
         [arguments addObject:[NSString stringWithFormat:@"xcode/%@-%@ xcode-wakatime/%@", XCODE_VERSION, XCODE_BUILD, VERSION]];


### PR DESCRIPTION
This is a first small fix for #17.
It works for simple Playgrounds, but maybe not for more sophisticated ones.

Here's the problem:
Almost always people code and write directly into one file. Which is what WakaTime can track. They can't track playgrounds, because its a folder. So I access the `Contents.swift` file inside the playground to track. This works for me.

As this is a ~~super~~ simple hack, there are some drawbacks: 
~~• WakaTime does not find a project for this file (aka the Playground?) → Appears in the "Unknown Project" list~~
• In the statistics it is listed as "Contents.swift" and not as the playground
• Might break